### PR TITLE
grammar: Ensure all captures have a 'name' key

### DIFF
--- a/grammars/perl6fe.cson
+++ b/grammars/perl6fe.cson
@@ -2489,7 +2489,7 @@
           '8':
             'begin': '('
             'beginCaptures':
-              '0': 'keyword.operator.paren.open.perl6fe'
+              '0': 'name': 'keyword.operator.paren.open.perl6fe'
             'end': ')'
             'endCaptures':
               '0': 'name': 'keyword.operator.paren.close.perl6fe'


### PR DESCRIPTION
Hey there! As you may know, we use this package to provide syntax highlighting for Perl 6 files in GitHub.

I'm currently working on improving the way we load and perform syntax highlighting on the website, and I've noticed that there's an issue in the existing grammar which is choking our new parser.

Specifically: there is a single `beginCaptures` group that is missing a `name` key. This is causing some small rendering issues because our parser expects all `beginCaptures` to have a name.

The proposed change fixes the issue in a backwards-compatible way. I'd appreciate if you could merge it. Thank you!