### PR TITLE
missing backslashes

### DIFF
--- a/grammars/perl6fe.cson
+++ b/grammars/perl6fe.cson
@@ -2397,7 +2397,7 @@
                 (?:
                    [\\p{Digit}\\p{Alpha}_]  # have alphanum/underscore or a ' or -
                 |                           # followed by an alphanum or underscore
-                   [\\-\'] [\\p{Digit}\\p{Alpha}_]
+                   [\\-\\'] [\\p{Digit}\\p{Alpha}_]
                 )*
             )'''
           'captures':
@@ -2435,7 +2435,7 @@
           (
              [\\p{Digit}\\p{Alpha}_]  # have alphanum/underscore or a ' or -
           |                           # followed by an alphanum or underscore
-             [\\-\'] [\\p{Digit}\\p{Alpha}_]
+             [\\-\\'] [\\p{Digit}\\p{Alpha}_]
           )*
           ( \\[ .* \\] )?             # postcircumfix [ ]
           ## methods
@@ -2447,7 +2447,7 @@
                   (?:
                     [\\p{Digit}\\p{Alpha}_]  # have alphanum/underscore or a ' or -
                   |                           # followed by an alphanum or underscore
-                    [\\-\'] [\\p{Digit}\\p{Alpha}_]
+                    [\\-\\'] [\\p{Digit}\\p{Alpha}_]
                   )*
 
               )


### PR DESCRIPTION
line 2400, 2438 and 2450 had a missing '\\'. Was `[\\-\']...` should be `[\\-\\']...`

(I didn't want to commit directly to master because I am not sure if this is right. Just started to explore this cson regexes.)