### PR TITLE
 Variable identifiers with embedded dashes/apostrophes highlight properly

### DIFF
--- a/grammars/perl6fe.cson
+++ b/grammars/perl6fe.cson
@@ -2393,11 +2393,11 @@
             (\\$|@|%|&)
             (\\.|\\*|:|!|\\^|~|=|\\?)?
             (
-                (?:[\\p{Alpha}_])             # Must start with Alpha or underscore
+                (?:[\\p{Alpha}_])           # Must start with Alpha or underscore
                 (?:
-                   [\\p{Digit}\\p{Alpha}_]  # have alphanum/underscore or a ' or -
-                |                           # followed by an alphanum or underscore
-                   [\\-\'] [\\p{Digit}\\p{Alpha}_]
+                   [\\p{Digit}\\p{Alpha}_]  # have alphanum/underscore, or a ' or -
+                |                           # followed by an Alpha or underscore
+                   [\\-\'] [\\p{Alpha}_]
                 )*
             )'''
           'captures':
@@ -2433,9 +2433,9 @@
           (\\.|\\*|:|!|\\^|~|=|\\?)?  # Twigils
           ([\\p{Alpha}_])             # Must start with Alpha or underscore
           (
-             [\\p{Digit}\\p{Alpha}_]  # have alphanum/underscore or a ' or -
-          |                           # followed by an alphanum or underscore
-             [\\-\'] [\\p{Digit}\\p{Alpha}_]
+             [\\p{Digit}\\p{Alpha}_]  # have alphanum/underscore, or a ' or -
+          |                           # followed by an Alpha or underscore
+             [\\-\'] [\\p{Alpha}_]
           )*
           ( \\[ .* \\] )?             # postcircumfix [ ]
           ## methods
@@ -2445,9 +2445,9 @@
               (
                  [\\p{Alpha}]
                   (?:
-                    [\\p{Digit}\\p{Alpha}_]  # have alphanum/underscore or a ' or -
-                  |                           # followed by an alphanum or underscore
-                    [\\-\'] [\\p{Digit}\\p{Alpha}_]
+                    [\\p{Digit}\\p{Alpha}_]  # have alphanum/underscore, or a ' or -
+                  |                          # followed by an Alpha or underscore
+                    [\\-\'] [\\p{Alpha}_]
                   )*
 
               )

--- a/spec/grammar-perl6fe-spec.coffee
+++ b/spec/grammar-perl6fe-spec.coffee
@@ -52,6 +52,15 @@ describe "Perl 6 FE grammar", ->
     'entity.name.section.boundary.regexp.perl6fe' ]
     expect(tokens[7]).toEqual value: ' ', scopes: [ 'source.perl6fe' ]
 
+  it "identifiers with embedded dash/apostroph highlight properly № 83", ->
+    {tokens} = grammar.tokenizeLine "$var-var-123 \"@var\'var-123\""
+    expect(tokens[1]).toEqual value: 'var-var',
+    scopes: [ 'source.perl6fe','meta.variable.container.perl6fe',
+    'variable.other.identifier.perl6fe' ]
+    expect(tokens[5]).toEqual value: "var\'var",
+    scopes: [ 'source.perl6fe', 'string.quoted.double.perl6fe',
+    'variable.other.identifier.interpolated.perl6fe' ]
+
   it "when before bare regex highlights properly", ->
     {tokens} = grammar.tokenizeLine "when / ^ /"
     expect(tokens[2]).toEqual value: '/', scopes: [


### PR DESCRIPTION
 Fixes #83

 Changes to be committed:
	modified:   grammars/perl6fe.cson
	modified:   spec/grammar-perl6fe-spec.coffee