### PR TITLE
Path to raku

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.17.0
+* Rename from 'Perl 6 FE' to 'Raku/Perl 6'
+* Change the description of the atom package to have Raku in it
+* Update README.md to mention Raku everywhere
+
 # v1.16.0
 * We now automate m// and s/// grammar generation using different delimiters.
   Now `m/ /`, `s/ / /`, `S/ / /`, `rx/ /` regex should work for more delimiters, and existing delimiters

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -5,7 +5,7 @@
 
 ```
 ### Picture [optional]
-> Providing a picture means that if the issue is fixed and linguist updates to include the fix (linguist uses this package to highlight Perl 6 on GitHub), your issue will remain historically viewable.
+> Providing a picture means that if the issue is fixed and linguist updates to include the fix (linguist uses this package to highlight Raku/Perl 6 on GitHub), your issue will remain historically viewable.
 
 ### Leave this in. For internal use.
 - [ ] Fixed in Master

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [fira-code]: https://github.com/tonsky/FiraCode
 [screenshot-1]: https://raw.githubusercontent.com/perl6/atom-language-perl6/master/images/example1.png
 
-# Atom Perl 6 Support - »ö« Official Edition!
+# Atom Raku/Perl 6 Support - »ö« Official Edition!
 
 [![apm package][apm-ver-link]][apm-pkg-link]
 [![][dl-badge]][apm-pkg-link]
@@ -26,17 +26,17 @@
 A colorful, thoughtful, and helpful language grammar for Perl 6! See
 [here](#how-do-i-use-this) for questions about usage.
 
-![A screenshot of an funnified Perl 6 file][screenshot-1]
+![A screenshot of an funnified Raku/Perl 6 file][screenshot-1]
 
 ## Integration
 This package has integration with the Atom [script][script-package] package.
 With both this package and the `script` package you can execute
-highlighted Perl 6 code or the whole document, even if it hasn't been saved using
+highlighted Raku/Perl 6 code or the whole document, even if it hasn't been saved using
 a keyboard shortcut.
 
 ## What Makes This The *Fun* Edition?
 
-> Perl 6 is optimized for fun. ― Audrey Tang
+> Perl 6 (Raku) is optimized for fun. ― Audrey Tang
 
 * This package was designed to work with [Fira Code][fira-code] ligatures
 
@@ -49,7 +49,7 @@ a keyboard shortcut.
 ## See something? Say something!
 See something highlighted incorrectly? See something LTA (Less Than Awesome)?
 Please report it on the [issue tracker][issues]. Any issue no matter how small
-should be reported. It is our hope that this is not only the best Perl 6
+should be reported. It is our hope that this is not only the best Raku/Perl 6
 highlighter for Atom, but the best highlighter for Atom out there.
 
 ## Contributing
@@ -68,7 +68,7 @@ line includes `use v6`, a shebang whose last term before any whitespace is
 If you are having issues, the `language-perl` package is probably taking
 precedence. To remedy this you can:
 
-* Click the language name in the status-bar (`Ctrl+Shift+L`) and select `Perl 6 FE`
+* Click the language name in the status-bar (`Ctrl+Shift+L`) and select `Raku/Perl 6`
 * If you want to permanently change the preferences for a file type,
   add the following to your `config.cson` (*Edit* → *Config*):
 

--- a/grammars/perl6fe.cson
+++ b/grammars/perl6fe.cson
@@ -1,5 +1,5 @@
 'scopeName': 'source.perl6fe'
-'name': 'Perl 6 FE'
+'name': 'Raku/Perl 6'
 'fileTypes': [
   'p6'
   'pl6'

--- a/grammars/perl6fe.cson
+++ b/grammars/perl6fe.cson
@@ -8,6 +8,8 @@
   't6'
   'pod6'
   'nqp'
+  'rakutest'
+  'raku'
 ]
 'firstLineMatch':
    '(?x) ^ \\s* (?:

--- a/grammars/perl6fe.cson
+++ b/grammars/perl6fe.cson
@@ -14,7 +14,7 @@
 'firstLineMatch':
    '(?x) ^ \\s* (?:
      use \\s v6 | =begin \\s pod | =comment
-     | \\#!(?: perl6|/.*perl6 (?! \\S))
+     | \\#!(?: (?:perl6|raku)|/.*(?:perl6|raku) (?! \\S))
      | my\\s*class
 )'
 'patterns': [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "language-perl6",
   "version": "1.16.1",
-  "description": "Perl 6 Language Highlighter",
+  "description": "Raku/Perl 6 Language Highlighter",
   "engines": {
     "atom": "*",
     "node": "*"


### PR DESCRIPTION
* Add support for .raku and .rakutest file extensions
* Add support for `raku` in the shebang #!
*  Update Atom package description for Raku
* Change name to 'Raku/Perl 6' from 'Perl 6 FE'