### PR TITLE
Modify META6.json highlighter

### DIFF
--- a/grammars/meta-info.tmLanguage.json
+++ b/grammars/meta-info.tmLanguage.json
@@ -39,11 +39,11 @@
       ]
     },
     "constant": {
-      "match": "\\b(?:true|false|null)\\b",
+      "match": "\\b(?:True|true|False|false|null)\\b",
       "name": "constant.language.json"
     },
     "fields": {
-      "match": "(?x) \"(?: perl|name|version|description|author(?:s)?|provides|depends|emulates| supersedes|superseded-by|excludes|build-depends|test-depends|resource| support|email|mailinglist|bugtracker|source|source-url|source-type| irc|phone|production|license|tags|auth )\"",
+      "match": "(?x) \"(?: perl|meta-version| name|version|description|authors|provides|depends|emulates| supersedes|superseded-by|excludes|build-depends|test-depends|resources| support|email|mailinglist|bugtracker|source|source-url|source-type| irc|phone|production|license|tags|auth )\"",
       "name": "entity.name.function.field.meta-info"
     },
     "number": {


### PR DESCRIPTION
+ As per https://design.raku.org/S22.html there is auth and authors field, so highlight those.
+ The META6 parser at https://github.com/jonathanstowe/META6 also uses True and False in addition to true and false

  Highlight those too !

+ Also its resources in META6, so change resource -> resources
+ Also add meta-version field